### PR TITLE
feat!: make `--release-version` required

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ on:
 env:
   SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
   E2E_TEST_SHOREBIRD_YAML: ${{ secrets.E2E_TEST_SHOREBIRD_YAML }}
+  RELEASE_VERSION: 0.1.0+1
 
 jobs:
   semantic-pull-request:
@@ -47,25 +48,18 @@ jobs:
       - name: ✨ Create New Flutter Project
         run: flutter create e2e_test --empty
 
-      - name: 🐦 Shorebird Init (MacOS/Linux)
-        if: runner.os != 'Windows'
-        run: echo "$E2E_TEST_SHOREBIRD_YAML" > shorebird.yaml
-        working-directory: e2e_test
+      - name: 📝 Adjust Pubspec Version
+        run: "sed -i '' 's/version: 0.1.0/version: ${{ env.RELEASE_VERSION }}/' e2e_test/pubspec.yaml"
 
-      - name: 🐦 Shorebird Init (Windows)
-        if: runner.os == 'Windows'
-        run: echo $env:E2E_TEST_SHOREBIRD_YAML > shorebird.yaml
-        working-directory: e2e_test
-
-      - name: 🐦 Shorebird Patch pubspec.yaml
-        run: |
-          echo "  assets:" >> pubspec.yaml
-          echo "    - shorebird.yaml" >> pubspec.yaml
-        working-directory: e2e_test
-
-      - name: 🐦 Shorebird Doctor
-        run: shorebird doctor --fix
-        working-directory: e2e_test
+      - name: 🐦 Shorebird Release
+        uses: shorebirdtech/shorebird-release@v0
+        id: shorebird-release
+        with:
+          args: --verbose
+          # TODO(felangel): add this when we upgrade to v1.
+          # flutter-version: latest
+          platform: android
+          working-directory: e2e_test
 
       - name: 🐦 Shorebird Patch (MacOS/Linux)
         if: runner.os != 'Windows'
@@ -74,6 +68,7 @@ jobs:
         with:
           args: --verbose
           platform: android
+          release-version: ${{ env.RELEASE_VERSION }}
           working-directory: e2e_test
 
       - name: 🐦 Shorebird Patch (Windows)
@@ -85,6 +80,7 @@ jobs:
           # macOS machine, so ignoring asset diffs for now.
           args: --verbose --allow-asset-diffs
           platform: android
+          release-version: ${{ env.RELEASE_VERSION }}
           working-directory: e2e_test
 
       - name: 🚦 Assert Patch Number (MacOS/Linux)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,8 @@ jobs:
         run: flutter create e2e_test --empty
 
       - name: 📝 Adjust Pubspec Version
-        run: "sed -i '' 's/version: 0.1.0/version: ${{ env.RELEASE_VERSION }}/' e2e_test/pubspec.yaml"
+        run: |
+          sed -i '' 's/version: 0.1.0/version: ${{ env.RELEASE_VERSION }}/' e2e_test/pubspec.yaml
 
       - name: 🐦 Shorebird Release
         uses: shorebirdtech/shorebird-release@v0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,12 +53,11 @@ jobs:
         working-directory: e2e_test
 
       - name: 🐦 Shorebird Release
-        uses: shorebirdtech/shorebird-release@v0
+        uses: shorebirdtech/shorebird-release@v1
         id: shorebird-release
         with:
           args: --verbose -- --build-name=${{ env.BUILD_NAME }} --build-number=${{ env.BUILD_NUMBER }}
-          # TODO(felangel): add this when we upgrade to v1.
-          # flutter-version: latest
+          flutter-version: latest
           platform: android
           working-directory: e2e_test
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,8 +12,8 @@ on:
 
 env:
   SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-  E2E_TEST_SHOREBIRD_YAML: ${{ secrets.E2E_TEST_SHOREBIRD_YAML }}
-  RELEASE_VERSION: 0.1.0+1
+  BUILD_NUMBER: 1
+  BUILD_NAME: 0.1.0
 
 jobs:
   semantic-pull-request:
@@ -48,10 +48,6 @@ jobs:
       - name: ✨ Create New Flutter Project
         run: flutter create e2e_test --empty
 
-      - name: 📝 Adjust Pubspec Version
-        run: |
-          sed -i '' 's/version: 0.1.0/version: ${{ env.RELEASE_VERSION }}/' e2e_test/pubspec.yaml
-
       - name: 🐦 Shorebird Init
         run: shorebird init --force
         working-directory: e2e_test
@@ -60,7 +56,7 @@ jobs:
         uses: shorebirdtech/shorebird-release@v0
         id: shorebird-release
         with:
-          args: --verbose
+          args: --verbose -- --build-name=${{ env.BUILD_NAME }} --build-number=${{ env.BUILD_NUMBER }}
           # TODO(felangel): add this when we upgrade to v1.
           # flutter-version: latest
           platform: android
@@ -73,7 +69,7 @@ jobs:
         with:
           args: --verbose
           platform: android
-          release-version: ${{ env.RELEASE_VERSION }}
+          release-version: "${{ env.BUILD_NAME }}+${{ env.BUILD_NUMBER }}"
           working-directory: e2e_test
 
       - name: 🐦 Shorebird Patch (Windows)
@@ -85,7 +81,7 @@ jobs:
           # macOS machine, so ignoring asset diffs for now.
           args: --verbose --allow-asset-diffs
           platform: android
-          release-version: ${{ env.RELEASE_VERSION }}
+          release-version: "${{ env.BUILD_NAME }}+${{ env.BUILD_NUMBER }}"
           working-directory: e2e_test
 
       - name: 🚦 Assert Patch Number (MacOS/Linux)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,6 +52,10 @@ jobs:
         run: |
           sed -i '' 's/version: 0.1.0/version: ${{ env.RELEASE_VERSION }}/' e2e_test/pubspec.yaml
 
+      - name: 🐦 Shorebird Init
+        run: shorebird init --force
+        working-directory: e2e_test
+
       - name: 🐦 Shorebird Release
         uses: shorebirdtech/shorebird-release@v0
         id: shorebird-release

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Shorebird
+Copyright (c) 2025 Shorebird
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Create a new patch using the [Shorebird CLI](https://github.com/shorebirdtech/sh
 
 ## Features
 
-✅ Create new Android patches
-
-✅ Create new iOS patches
+✅ Create new releases for iOS, Android, macOS, Linux, and Windows
 
 ✅ Outputs the patch number
 
@@ -17,11 +15,12 @@ Create a new patch using the [Shorebird CLI](https://github.com/shorebirdtech/sh
 
 ```yaml
 steps:
-  - uses: shorebirdtech/setup-shorebird@v0
-  - uses: shorebirdtech/shorebird-patch@v0
+  - uses: shorebirdtech/setup-shorebird@v1
+  - uses: shorebirdtech/shorebird-patch@v1
     id: shorebird-patch
     with:
       platform: android
+      release-version: latest
       working-directory: ./path/to/app
 
   - run: echo patch-number ${{ steps.shorebird-patch.outputs.patch-number }}
@@ -35,6 +34,8 @@ The action takes the following inputs:
 - `args`: Any arguments to pass to `shorebird patch`.
   - Use an extra `--` to pass arguments to Flutter (e.g. `-- --dart-define=KEY=VALUE`)
 - `platform`: Which platform to create a patch for (e.g. `android` or `ios`)
+- `release-version`: Which release version to patch.
+  - Use `latest` to target the release that was most recently updated.
 - `working-directory`: Which directory to run `shorebird patch` in.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   platform:
     description: The platform for which to create a patch (e.g. android, ios)
     required: true
+  release-version:
+    description: The release version to patch (e.g. 1.0.0+1). Use "latest" to target the release that was most recently updated.
+    required: true
   working-directory:
     description: The working directory in which to run Shorebird
     required: false
@@ -31,7 +34,7 @@ runs:
       id: shorebird-patch
       working-directory: ${{ inputs.working-directory }}
       run: |
-        shorebird patch ${{ inputs.platform }} ${{ inputs.args }} | tee output.log
+        shorebird patch ${{ inputs.platform }} --release-version ${{ inputs.release-version }} ${{ inputs.args }} | tee output.log
         GREP_MATCH=$(grep -Ei "Published Patch (.*)" output.log)
         if [[ $GREP_MATCH ]]; then
           # Strip the non-version-number characters from the line


### PR DESCRIPTION
This is a breaking change which adds a required `release-version` input to the action which should eliminate the need for shorebird to infer the release version which potentially results in a double build.

Related to https://github.com/shorebirdtech/shorebird/issues/1945